### PR TITLE
Pin poetry verison

### DIFF
--- a/.github/workflows/deploy-custom-domain.yml
+++ b/.github/workflows/deploy-custom-domain.yml
@@ -93,8 +93,9 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
+      # pin version for poetry as higher versions have PEP 440 versioning issues
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.1.15
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/remove-custom-domain.yml
+++ b/.github/workflows/remove-custom-domain.yml
@@ -76,9 +76,10 @@ jobs:
       - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
+      
+      # pin version for poetry as higher versions have PEP 440 versioning issues
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.1.15
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -57,8 +57,8 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
+      # pin version for poetry as higher versions have PEP 440 versioning issues
       - name: Install poetry
-        # pin version for poetry as higher versions have PEP 440 versioning issues
         run: pipx install poetry==1.1.15
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -58,7 +58,8 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Install poetry
-        run: pipx install poetry
+        # pin version for poetry as higher versions have PEP 440 versioning issues
+        run: pipx install poetry==1.1.15
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Description

Pin `poetry` version to `1.1.15`
- Later versions (`1.2.0` onwards) introduce `PEP 440` versioning constraints
- `PEP 440` require updating versions: eg:
  - `1.1.0.properly` -> `1.1.0+.properly` and needs to be tested

## For Reviewers

(add any notes for reviewers)
