### PR TITLE
Pass in PRODUCT_DATABASE_CLUSTER to create domain step

### DIFF
--- a/.github/workflows/deploy-custom-domain.yml
+++ b/.github/workflows/deploy-custom-domain.yml
@@ -142,6 +142,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          PRODUCT_DATABASE_CLUSTER: ${{ needs.check_comment.outputs.database_cluster }}
 
       - name: Deploy custom domain
         run: poetry run inv deploy --stage ${{ steps.deployment_custom.outputs.env }}


### PR DESCRIPTION
## Description

Seeing the following in an attempted deploy
```
Error:
Cannot resolve serverless.yml: Variables resolution errored with:
  - Cannot resolve variable at "custom.secretsArnPrefix": Value not found at "env" source,
  - Cannot resolve variable at "resources.4": Value not found at "file" source
 ```
Looking at serverless.yaml the issue seems to be with the env variable fallback not being there
```
  secretsArnPrefix: ${self:custom.properlyStageData.${self:provider.stage}.secretsArnPrefix, env:PRODUCT_DATABASE_CLUSTER}
```

## For Reviewers

(add any notes for reviewers)
