### PR TITLE
feat: add option for removing dev dependencies from deployment package

### DIFF
--- a/.github/workflows/deploy-custom-domain.yml
+++ b/.github/workflows/deploy-custom-domain.yml
@@ -14,6 +14,9 @@ on:
       run_typecheck:
         description: 'A boolean value to run typecheck step (default false)'
         type: boolean
+      remove_dev_deps:
+        description: "A boolean value to remove dev dependencies before deploying (default false)"
+        type: boolean
 
 jobs:
   check_comment:
@@ -126,6 +129,14 @@ jobs:
         with:
           files: "${{ inputs.working_directory }}/tests/*.xml"
           comment_mode: "always"
+
+      - name: Remove dependencies and reinstall prod dependencies
+        if: inputs.remove_dev_deps
+        run: |
+          rm -rf .venv
+          poetry env use ${{ needs.python_version.outputs.version }}
+          poetry config http-basic.properly "${{ secrets.PIP_GEMFURY_DEPLOY_TOKEN }}" NOPASS
+          poetry install --without dev
 
       - name: Start deployment
         id: deployment_custom

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,6 +17,9 @@ on:
       run_typecheck:
         description: 'A boolean value to run typecheck step (default false)'
         type: boolean
+      remove_dev_deps:
+        description: "A boolean value to remove dev dependencies before deploying (default false)"
+        type: boolean
 
 jobs:
   python_version:
@@ -97,6 +100,14 @@ jobs:
         with:
           files: "${{ inputs.working_directory }}/tests/*.xml"
           comment_mode: "always"
+      
+      - name: Remove dependencies and reinstall prod dependencies
+        if: inputs.remove_dev_deps
+        run: |
+          rm -rf .venv
+          poetry env use ${{ needs.python_version.outputs.version }}
+          poetry config http-basic.properly "${{ secrets.PIP_GEMFURY_DEPLOY_TOKEN }}" NOPASS
+          poetry install --without dev
 
       - name: Start deployment
         id: deployment_staging

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -37,6 +37,9 @@ on:
       run_static_metrics:
         description: "A boolean value to run static code analysis and report them to Datadog (default false)"
         type: boolean
+      remove_dev_deps:
+        description: "A boolean value to remove dev dependencies before deploying (default false)"
+        type: boolean
       skip_domain_creation:
         description: "A boolean value to skip domain creation for legacy repos (default false)"
         type: boolean
@@ -106,6 +109,14 @@ jobs:
         run: poetry run inv datadog-ci
         env:
           DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
+
+      - name: Remove dependencies and reinstall prod dependencies
+        if: inputs.remove_dev_deps
+        run: |
+          rm -rf .venv
+          poetry env use ${{ needs.python_version.outputs.version }}
+          poetry config http-basic.properly "${{ secrets.PIP_GEMFURY_DEPLOY_TOKEN }}" NOPASS
+          poetry install --without dev
 
       - name: Start deployment (staging)
         id: deployment_staging


### PR DESCRIPTION
## Description

Adds a new variable `remove_dev_deps` to three workflows:
- test and deploy
- deploy staging
- deploy custom stage

When turned on, the workflows will remove dev dependencies and only install production ones after linting and testing.

## For Reviewers

(add any notes for reviewers)
