### PR TITLE
INFR-243 Fix to report default branch in metrics

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -279,7 +279,7 @@ jobs:
               tags:
                 - "repository:${{ github.repository }}"
                 - "workflow:${{ github.workflow }}"
-                - "default_branch:${{ github.ref_name == inputs.main_branch }}"
+                - "default_branch:${{ github.ref == format('refs/heads/{0}', inputs.default_branch) }}"
             - type: "count"
               name: "properly.ci.code.metrics.sloc"
               value: ${{ fromJSON( steps.compute_raw_sum.outputs.RAW_SUMMARY ).sloc }}
@@ -287,7 +287,7 @@ jobs:
               tags:
                 - "repository:${{ github.repository }}"
                 - "workflow:${{ github.workflow }}"
-                - "default_branch:${{ github.ref_name == inputs.main_branch }}"
+                - "default_branch:${{ github.ref == format('refs/heads/{0}', inputs.default_branch) }}"
             - type: "count"
               name: "properly.ci.code.metrics.lloc"
               value: ${{ fromJSON( steps.compute_raw_sum.outputs.RAW_SUMMARY ).lloc }}
@@ -295,7 +295,7 @@ jobs:
               tags:
                 - "repository:${{ github.repository }}"
                 - "workflow:${{ github.workflow }}"
-                - "default_branch:${{ github.ref_name == inputs.main_branch }}"
+                - "default_branch:${{ github.ref == format('refs/heads/{0}', inputs.default_branch) }}"
             - type: "count"
               name: "properly.ci.code.metrics.file_count"
               value: ${{ steps.compute_cc_file_count.outputs.CC_FILE_COUNT }}
@@ -303,7 +303,7 @@ jobs:
               tags:
                 - "repository:${{ github.repository }}"
                 - "workflow:${{ github.workflow }}"
-                - "default_branch:${{ github.ref_name == inputs.main_branch }}"
+                - "default_branch:${{ github.ref == format('refs/heads/{0}', inputs.default_branch) }}"
             - type: "count"
               name: "properly.ci.code.metrics.function_count"
               value: ${{ steps.compute_cc_function_count.outputs.CC_FUNCTION_COUNT }}
@@ -311,7 +311,7 @@ jobs:
               tags:
                 - "repository:${{ github.repository }}"
                 - "workflow:${{ github.workflow }}"
-                - "default_branch:${{ github.ref_name == inputs.main_branch }}"
+                - "default_branch:${{ github.ref == format('refs/heads/{0}', inputs.default_branch) }}"
             - type: "count"
               name: "properly.ci.code.metrics.class_count"
               value: ${{ steps.compute_cc_class_count.outputs.CC_CLASS_COUNT }}
@@ -319,7 +319,7 @@ jobs:
               tags:
                 - "repository:${{ github.repository }}"
                 - "workflow:${{ github.workflow }}"
-                - "default_branch:${{ github.ref_name == inputs.main_branch }}"
+                - "default_branch:${{ github.ref == format('refs/heads/{0}', inputs.default_branch) }}"
             - type: "count"
               name: "properly.ci.code.metrics.method_count"
               value: ${{ steps.compute_cc_method_count.outputs.CC_METHOD_COUNT }}
@@ -327,4 +327,4 @@ jobs:
               tags:
                 - "repository:${{ github.repository }}"
                 - "workflow:${{ github.workflow }}"
-                - "default_branch:${{ github.ref_name == inputs.main_branch }}"
+                - "default_branch:${{ github.ref == format('refs/heads/{0}', inputs.default_branch) }}"


### PR DESCRIPTION
## Description

* Found a problem in the reported metrics where it always gets tagged with `default_branch: false` despite it running on main
* The conditional for the job seems to work, use that expression instead

## For Reviewers

(add any notes for reviewers)
