### PR TITLE
Replace deprecated set-output with environment files

### DIFF
--- a/.github/workflows/deploy-custom-domain.yml
+++ b/.github/workflows/deploy-custom-domain.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Extract Domain Name
         id: extract_domain_name
-        run: echo ::set-output name=extracted_domain::$(echo ${{ github.event.comment.body }} | sed -n 's/^deploy STAGE=\([a-zA-Z0-9.-]*\).*/\L\1/p')
+        run: echo extracted_domain=$(echo ${{ github.event.comment.body }} | sed -n 's/^deploy STAGE=\([a-zA-Z0-9.-]*\).*/\L\1/p') >> $GITHUB_OUTPUT
 
       - name: Debug stage output
         run: echo ::debug::${{ steps.extract_domain_name.outputs.extracted_domain }}
@@ -40,7 +40,7 @@ jobs:
         id: extract_database_cluster
         # if stage is staging, DB Cluster will not override
         if: steps.extract_domain_name.outputs.extracted_domain != '' && steps.extract_domain_name.outputs.extracted_domain != 'staging'
-        run: echo ::set-output name=extracted_database_cluster::$(echo ${{ github.event.comment.body }} | sed -n 's/^deploy STAGE=\([a-zA-Z0-9.-]*\) PRODUCT_DATABASE_CLUSTER=\([a-zA-Z0-9._-]*\).*/\2/p')
+        run: echo extracted_database_cluster=$(echo ${{ github.event.comment.body }} | sed -n 's/^deploy STAGE=\([a-zA-Z0-9.-]*\) PRODUCT_DATABASE_CLUSTER=\([a-zA-Z0-9._-]*\).*/\2/p') >> $GITHUB_OUTPUT
 
       - name: Debug cluster output
         run: echo ::debug::${{ steps.extract_database_cluster.outputs.extracted_database_cluster }}

--- a/.github/workflows/python-version.yml
+++ b/.github/workflows/python-version.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Python Version
         id: python_version
-        run: echo ::set-output name=version::$(cat ${{ inputs.python_version_file }})
+        run: echo version=$(cat ${{ inputs.python_version_file }}) >> $GITHUB_OUTPUT
 
       - name: Report extracted Python version
         run: echo ::debug::${{ steps.python_version.outputs.version }}

--- a/.github/workflows/remove-custom-domain.yml
+++ b/.github/workflows/remove-custom-domain.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - name: Extract Stage Name
         id: extract_stage_name
-        run: echo ::set-output name=stage_name::$(echo ${{ github.event.comment.body }} | sed -n 's/^remove STAGE=\([a-zA-Z0-9.-]*\).*/\1/p')
-      
+        run: echo stage_name=$(echo ${{ github.event.comment.body }} | sed -n 's/^remove STAGE=\([a-zA-Z0-9.-]*\).*/\1/p') >> $GITHUB_OUTPUT
+
       - name: Debug stage output
         run: echo ::debug::${{ steps.extract_stage_name.outputs.stage_name }}
 


### PR DESCRIPTION
## Description

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

> We are monitoring telemetry for the usage of these commands and plan to fully disable them on 31st May 2023

This comes from CI warnings:
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
