### PR TITLE
[GING-306] Pin Poetry version to 1.4.2

### DIFF
--- a/.github/workflows/deploy-custom-domain.yml
+++ b/.github/workflows/deploy-custom-domain.yml
@@ -97,7 +97,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.4.2
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -68,7 +68,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.4.2
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/remove-custom-domain.yml
+++ b/.github/workflows/remove-custom-domain.yml
@@ -78,7 +78,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.4.2
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -71,7 +71,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.4.2
 
       - uses: actions/setup-python@v4
         with:
@@ -209,7 +209,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.4.2
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
It seems like 1.5.0 ([released 4 days ago](https://github.com/python-poetry/poetry/releases/tag/1.5.0)) has [broken deployments](https://github.com/GoProperly/properties/actions/runs/5062171138/jobs/9087350984) in the properties service. 1.4.2 was the last working version in [our CI logs](https://github.com/GoProperly/properties/actions/runs/5018041680/jobs/8996941907). Hopefully this will fix the deployments until we can work out why 1.5.0 breaks with the properties service.

Favourites service deployed fine with 1.5.0. https://github.com/GoProperly/favourite-listings/actions/runs/5062324583/jobs/9087704198

This is the issue I found in properties service, although closed with nothing helpful added: https://github.com/python-poetry/poetry-plugin-export/issues/112

## Description

(briefly describe what this pull request does)

## For Reviewers

(add any notes for reviewers)
